### PR TITLE
Introducing a people page

### DIFF
--- a/people.md
+++ b/people.md
@@ -1,0 +1,11 @@
+---
+title: People
+---
+Something New is a open and collaborative party built on consensus, so the voices of all members count. We do have to have official roles to comply with electoral law so these are outlined here.
+
+## Officers
+Officers of the party are official roles registered with the Electoral Commission. Some are required by law, others are made up at our discretion.
+
+* James Smith - Leader & Treasurer
+* Paul Robinson - Nominating Officer
+* Philip John - Officer


### PR DESCRIPTION
Starting with officers, I want to add individual pages for each person with contact details that could also pull from our Popolo data.

We should also add other key people. For example, once we start giving people more permanent roles, as we're doing with GE2017, we can add them here so folks know who to turn to for individual issues.